### PR TITLE
fix: Adding error validation to Solana RPC error

### DIFF
--- a/src/pages/[username].tsx
+++ b/src/pages/[username].tsx
@@ -44,10 +44,12 @@ const ProfilePage = ({ user }: ProfilePageProps) => {
   const checkIfLeaderHasFakeID = React.useCallback(async () => {
     try {
       await getNFTWithMetadata(user.fakeID);
-    } catch (e) {
-      setDiseased(true);
-      markUserAsDiseased(user._id);
-      setSelectedLeader((prev) => ({ ...prev, deceased: true }));
+    } catch (e: any) {
+      if (e?.toString()?.includes("AccountNotFoundError")) {
+        setDiseased(true);
+        markUserAsDiseased(user._id);
+        setSelectedLeader((prev) => ({ ...prev, deceased: true }));
+      }
     }
     // eslint-disable-next-line
   }, []);


### PR DESCRIPTION
Adding error validation to Solana RPC error when trying to check… if Fake ID exists